### PR TITLE
add python3-devel and source URL…

### DIFF
--- a/slackfix.spec
+++ b/slackfix.spec
@@ -23,8 +23,8 @@ Summary:        Wrapper script to fix Slack flaw
 License:        GPL-2.0-only
 Group:          Productivity/Networking/Other
 URL:            https://github.com/frispete/%{name}
-Source:         %{name}-%{version}.tar.gz
-BuildRequires:  python3-setuptools
+Source:         %{URL}/archive/refs/tags/v%{version}.tar.gz
+BuildRequires:  python3-devel python3-setuptools
 BuildRequires:  systemd-rpm-macros
 BuildArch:      noarch
 


### PR DESCRIPTION
Add python3-devel to build requirements to fix build failure, add URL for source to allow usage with spectool

(1) Without python3-devel build requirement the package fails to build with the following error:
```
RPM build errors:
    source_date_epoch_from_changelog set but %changelog is missing
    File must begin with "/": %{python3_sitelib}/{,__pycache__/}slackfix*
```
(2) By adding the URL for the latest release we can simply clone the repo and run `spectool -g *.spec` inside the cloned folder to grab the latest tarball automagically.

Doing so simplifies the build process:
```
git clone https://github.com/frispete/slackfix
cd slackfix
spectool -g *.spec
fedpkg --release f39 srpm
mock -r /etc/mock/fedora-39-x86_64.cfg --rebuild --enable-network *.src.rpm
mv /var/lib/mock/fedora-39-x86_64/result .
sudo dnf install result/slackfix-0.1.3-0.noarch.rpm
```